### PR TITLE
Compatibility with keras >= 3.11.3

### DIFF
--- a/src/smlp_py/train_keras.py
+++ b/src/smlp_py/train_keras.py
@@ -370,7 +370,7 @@ class ModelKeras:
             for k, v in self._loss_functions.items():
                 if str(v) in str(model.loss) or str(k) in str(model.loss):
                     self._keras_logger.info("Loss function: " + str(k))
-        if hasattr(model, 'compiled_metrics'):
+        if hasattr(model, 'compiled_metrics') and hasattr(model.compiled_metrics, '_metrics'):
             compiled_metrics = model.compiled_metrics._metrics  # Access the private _metrics attribute
             self._keras_logger.info("Metrics: " + str([m.name for m in compiled_metrics]))
         else:
@@ -900,5 +900,3 @@ class ModelKeras:
                 seed, weights_coef, model_per_response)
         self._keras_logger.info('keras_main: end')
         return model
-
-    


### PR DESCRIPTION
Fix access to non-existing private attribute `_metrics` occuring e.g. when running regression test no. 4:
```
Traceback (most recent call last):
  File "/home/kane/intel/smlp/regr_smlp/code/../../src/run_smlp.py", line 18, in <module>
    main(sys.argv)
  File "/home/kane/intel/smlp/regr_smlp/code/../../src/run_smlp.py", line 15, in main
    smlpInst.smlp_flow()
  File "/home/kane/intel/smlp/src/smlp_py/smlp_flows.py", line 317, in smlp_flow
    model = self.modelInst.build_models(args.model, X, y, X_train, y_train, X_test, y_test, X_new, y_new,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kane/intel/smlp/src/smlp_py/smlp_models.py", line 472, in build_models
    model = self.model_train(feat_names_dict, resp_names, algo, X_train, X_test, y_train, y_test,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kane/intel/smlp/src/smlp_py/smlp_models.py", line 353, in model_train
    model = self._instKeras.keras_main(resp_names, keras_algo, X_train, X_test, y_train, y_test, hparams_dict, plots,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kane/intel/smlp/src/smlp_py/train_keras.py", line 924, in keras_main
    model = self._keras_train_multi_response(resp_names, algo,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kane/intel/smlp/src/smlp_py/train_keras.py", line 865, in _keras_train_multi_response
    history = self._nn_train(model, epochs, batch_size, weights_precision, self.model_checkpoint_pattern,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kane/intel/smlp/src/smlp_py/train_keras.py", line 475, in _nn_train
    self._log_model_summary(model, epochs, batch_size, sample_weights_dict, callbacks)
  File "/home/kane/intel/smlp/src/smlp_py/train_keras.py", line 380, in _log_model_summary
    compiled_metrics = model.compiled_metrics._metrics  # Access the private _metrics attribute
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DeprecatedCompiledMetric' object has no attribute '_metrics'
```
Also affects regression tests 13, 28, 149, 150, 151, 152, 154, 155, 156, 157, 158, 172, 173, 174, 175, 176, 177, 178, 179, 180.