### PR TITLE
Add homepage and license info to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ maintainers = [
 name = "smlptech"
 dynamic = ["version"]
 description = "SMLP - The Symbolic Machine Learning Prover"
+license = "Apache-2.0"
+license-files = [
+	"LICENSE",
+	"AUTHORS",
+]
 readme = "README.md"
 requires-python = "==3.11.*"
 dependencies = [
@@ -37,6 +42,9 @@ dependencies = [
     "seaborn",
     "tensorflow==2.15.1",
 ]
+
+[project.urls]
+homepage = "https://github.com/SMLP-Systems/smlp"
 
 [project.scripts]
 smlp = "smlp.run_smlp:main2"


### PR DESCRIPTION
With this change, `pip show smlptech` prints for me
```
Name: smlptech
Version: 1.2.1rc5.dev34+g09a838a88
Summary: SMLP - The Symbolic Machine Learning Prover
Home-page: https://github.com/SMLP-Systems/smlp
Author: 
Author-email: 
License-Expression: Apache-2.0
Location: /home/kane/.local/lib/python3.11/site-packages
Requires: doepy, jenkspy, keras-tuner, matplotlib, mrmr-selection, pandas, pycaret, pyDOE, pysubgroup, scikit-learn, scipy, seaborn, tensorflow
Required-by: 
```
Before, homepage and license info was unset, see also #106.