### PR TITLE
Readme: remove section for outdated Ubuntu-22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,47 +180,6 @@ tests/install/test_container_install mdmitry1/python311-dev
 
 </details>
 
-
-### Sources
-<details>
- <summary> Installation on a stock Ubuntu-22.04 </summary>
- 
-``` 
-	sudo apt install \
-		python3-pip ninja-build z3 libz3-dev libboost-python-dev texlive \
-		pkg-config libgmp-dev libpython3-all-dev python-is-python3
-	# get a recent version of the meson configure tool
-	pip install --user meson
-
-	# obtain sources
-	git clone https://github.com/fbrausse/kay.git
-	git clone https://github.com/smlp-systems/smlp.git
-	cd smlp/utils/poly
-
-	# workaround <https://bugs.launchpad.net/ubuntu/+source/swig/+bug/1746755>
-	echo 'export PYTHONPATH=$HOME/.local/lib/python3/dist-packages:$PYTHONPATH' >> ~/.profile
-	# get $HOME/.local/bin into PATH and get PYTHONPATH
-	mkdir -p $HOME/.local/bin
-	source ~/.profile
-
-	# setup, build & install libsmlp
-	meson setup -Dkay-prefix=$HOME/kay --prefix $HOME/.local build
-	ninja -C build install
-
-	# tensorflow-2.16 has a change leading to the error:
-	# 'The filepath provided must end in .keras (Keras model format).'
-	pip install --user \
-		pandas tensorflow==2.15.1 scikit-learn pycaret seaborn \
-		mrmr-selection jenkspy pysubgroup pyDOE doepy
-```                
-
- </details>
-
-<details>
- <summary> MacOS </summary>
-   Installation instructions for Ubuntu-22.04 can be followed using `homebrew` in place of `apt`
-</details>
-
 ## Quickstart
 
 ### Problem: find minimal distance between point (2,1) and unit circle<br>


### PR DESCRIPTION
Now that we've got a wheel on PyPI and did confirm multiple times that the new instructions for Ubuntu-24.04 for it work fine, I don't think we need the very specific and superseded instructions for Ubuntu-22.04 anymore. They might be interesting for people who want to actually build SMLP (e.g., `pip install .`) or a wheel, but there is no need to keep them in the Readme.