### PR TITLE
Synchronize SMLP version populated by run_dora script with the installed wheel

### DIFF
--- a/scripts/github/smlp_release_info.py
+++ b/scripts/github/smlp_release_info.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3.11
+import requests
+from bs4 import BeautifulSoup
+import re
+from sys import argv
+from os.path import basename
+
+def get_commit_info_from_github_release(url):
+    """
+    Extracts the commit hash and commit date from a GitHub release page URL
+    without using git.
+
+    Args:
+        url (str): The URL of the GitHub release page (e.g.,
+                   "https://github.com/SMLP-Systems/smlp/releases/tag/v1.2.3rc7").
+
+    Returns:
+        dict or None: A dictionary with 'commit_hash' and 'commit_date' if found,
+                      otherwise None.
+    """
+    headers = {
+        # Mimic a real browser to avoid being blocked by GitHub
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/124.0.0.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching the URL '{url}': {e}")
+        return None
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+
+    commit_hash = None
+    commit_date = None
+
+    commit_link_pattern = re.compile(r'/commit/([0-9a-fA-F]{40})')
+
+    # --- Strategy 1: Find the commit link and look for a sibling <time> element ---
+    for link in soup.find_all('a', href=True):
+        match = commit_link_pattern.search(link['href'])
+        if match:
+            commit_hash = match.group(1)
+
+            # Walk up the DOM tree to find a nearby <time> or <relative-time> tag
+            # GitHub places the commit timestamp close to the commit link
+            parent = link.parent
+            for _ in range(6):  # Search up to 6 levels up the DOM
+                if parent is None:
+                    break
+
+                # Look for <relative-time> (GitHub's custom element) or <time>
+                time_tag = parent.find(['relative-time', 'time'])
+                if time_tag:
+                    # 'datetime' attribute holds the ISO 8601 timestamp
+                    commit_date = time_tag.get('datetime') or time_tag.get_text(strip=True)
+                    break
+
+                parent = parent.parent
+
+            # Stop after the first valid commit link is found
+            break
+
+    # --- Strategy 2: Fallback - scan ALL <time> / <relative-time> tags on page ---
+    if commit_hash and not commit_date:
+        for time_tag in soup.find_all(['relative-time', 'time']):
+            dt = time_tag.get('datetime')
+            if dt:
+                commit_date = dt
+                break
+
+    if not commit_hash:
+        print("Could not find a commit hash on the page.")
+        return None
+
+    return {
+        "commit_hash": commit_hash,
+        "commit_date": commit_date or "Date not found"
+    }
+
+
+# --- Example Usage ---
+if __name__ == "__main__":
+    if len(argv) < 2:
+        print(f"\nUsage: {basename(argv[0])} <tag name>\n")
+        exit(1)
+
+    release_url = f"https://github.com/SMLP-Systems/smlp/releases/tag/{argv[1]}"
+
+    print(f"Fetching release info from:\n  {release_url}\n")
+    info = get_commit_info_from_github_release(release_url)
+
+    if info:
+        print(f"  Commit Hash : {info['commit_hash']}")
+        print(f"  Commit Date : {info['commit_date']}")
+    else:
+        print("Failed to retrieve release information.")
+

--- a/scripts/venv/run_dora
+++ b/scripts/venv/run_dora
@@ -35,6 +35,22 @@ elif [[ -v wheel ]]; then
 else
     pip install smlptech
 fi
+smlptech_version=$(pip show smlptech | grep ^Version | awk '{print $NF}')
+if [[ "$smlptech_version" == *"+g"* ]]; then
+    commit="${smlptech_version##*+g}"
+else
+    tag=v"$smlptech_version"
+    pip install requests beautifulsoup4
+    smlp_release_info=$(git rev-parse --show-toplevel)/scripts/github/smlp_release_info.py
+    commit=$($smlp_release_info v"$smlptech_version" | grep "Commit Hash" | awk '{print $NF}')
+fi
+if [[ -v tag ]]; then
+    echo "Tag: $tag"
+fi
+echo "Commit: $commit"
+checkout_cmd="git checkout $commit"
+echo $checkout_cmd
+$checkout_cmd
 sed -i.bak "s@../../src/run_smlp.py@smlp@" regr_smlp/code/smlp_regr.py
 cd regr_smlp/code
 smlp -data "../data/smlp_toy_num_resp_mult.csv" -out_dir ./ -pref Test1 -mode train -resp y1 -feat x,p1,p2 -model dt_caret -save_model_config f -mrmr_pred 0 -plots t -seed 10 -log_time f

--- a/scripts/venv/run_dora
+++ b/scripts/venv/run_dora
@@ -28,7 +28,7 @@ $(dirname $mathsat_src_dir)/run_mathsat_build
 \rm -rf $mathsat_dest_dir > /dev/null
 \mv $mathsat_src_dir $mathsat_dest_dir
 if [[ -v test ]]; then
-    pip install requests packaging
+    pip install packaging
     pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple smlptech==$($script_path/../bin/smlp_versions.py -atl)
 elif [[ -v wheel ]]; then
     pip install $wheel

--- a/scripts/venv/run_dora
+++ b/scripts/venv/run_dora
@@ -28,7 +28,7 @@ $(dirname $mathsat_src_dir)/run_mathsat_build
 \rm -rf $mathsat_dest_dir > /dev/null
 \mv $mathsat_src_dir $mathsat_dest_dir
 if [[ -v test ]]; then
-    pip install packaging
+    pip install requests packaging
     pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple smlptech==$($script_path/../bin/smlp_versions.py -atl)
 elif [[ -v wheel ]]; then
     pip install $wheel
@@ -40,7 +40,7 @@ if [[ "$smlptech_version" == *"+g"* ]]; then
     commit="${smlptech_version##*+g}"
 else
     tag=v"$smlptech_version"
-    pip install requests beautifulsoup4
+    pip install beautifulsoup4
     smlp_release_info=$(git rev-parse --show-toplevel)/scripts/github/smlp_release_info.py
     commit=$($smlp_release_info v"$smlptech_version" | grep "Commit Hash" | awk '{print $NF}')
 fi

--- a/scripts/venv/run_dora
+++ b/scripts/venv/run_dora
@@ -42,7 +42,7 @@ else
     tag=v"$smlptech_version"
     pip install beautifulsoup4
     smlp_release_info=$(git rev-parse --show-toplevel)/scripts/github/smlp_release_info.py
-    commit=$($smlp_release_info v"$smlptech_version" | grep "Commit Hash" | awk '{print $NF}')
+    commit=$($smlp_release_info $tag | grep "Commit Hash" | awk '{print $NF}')
 fi
 if [[ -v tag ]]; then
     echo "Tag: $tag"


### PR DESCRIPTION
Example:
```
smlp_release_info.py v1.2.3rc15
```

```
Fetching release info from:
  https://github.com/SMLP-Systems/smlp/releases/tag/v1.2.3rc15

  Commit Hash : 9d73c45c858c9411172b1970fb92a0fd84f34f38
  Commit Date : 2026-05-13T08:00:39Z
```

Additional dependency: `beautifulsoup4`

