### PR TITLE
Added Docker images for Ubuntu 26.04

### DIFF
--- a/scripts/docker/Dockerfile.python311-dev_26.04
+++ b/scripts/docker/Dockerfile.python311-dev_26.04
@@ -1,0 +1,96 @@
+# Use ubuntu 24.04 as an image
+FROM ubuntu:26.04
+
+ARG RELEASE_TYPE
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Layer 1: base tools
+RUN apt-get update && apt-get install -y \
+    wget \
+    vim \
+    git \
+    jq \
+    libgomp1 \
+    tcsh \
+    tzdata \
+    locales
+
+# Layer 2: Python 3.11
+RUN apt-get install -y --no-install-recommends \
+        gnupg curl ca-certificates && \
+        curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" \
+            | gpg --dearmor -o /etc/apt/trusted.gpg.d/deadsnakes.gpg && \
+        echo "deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu resolute main" \
+            > /etc/apt/sources.list.d/deadsnakes.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3.11 python3.11-tk python3.11-venv && \
+    python3.11 -m ensurepip
+
+# Layer 4: X11 and GUI tools
+RUN apt-get install -y \
+    tk \
+    tkcvs \
+    libx11-6 \
+    libxext6 \
+    libxrender1 \
+    libxtst6 \
+    libxi6 \
+    x11-apps \
+    x11-xserver-utils \
+    x11vnc \
+    xvfb \
+    vim \
+    autocutsel \
+    && rm -rf /var/lib/apt/lists/*
+
+# Layer 5: Install smlptech
+WORKDIR /app
+COPY run_pip_install  .
+COPY smlp_versions.py .
+RUN ./run_pip_install $RELEASE_TYPE
+
+#Change python default version
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python3
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python
+
+# Layer 6: Validate installation
+RUN PYTHON="python3.11" \ 
+ && printf '#!/bin/bash\nset -e\n' > validate.sh \
+ && printf '%s -c "import smlp; from importlib.metadata import version; print('"'"'smlp version:'"'"', version('"'"'smlptech'"'"'))"\n' "$PYTHON" >> validate.sh \
+ && printf '%s -c "import tkinter; print('"'"'tkinter Tcl/Tk:'"'"', tkinter.TclVersion)"\n'                                             "$PYTHON" >> validate.sh \
+RUN ./validate.sh
+
+# Layer 6: Mathsat 
+COPY run_mathsat_build .
+RUN ./run_mathsat_build && rm -rf /tmp/mathsat*
+
+#Layer 7: tkdiff patch for https://bugs.launchpad.net/bugs/2139062
+COPY run_tkdiff_patch .
+RUN ./run_tkdiff_patch
+
+#Layer 8: git clone
+RUN echo "Building image for branch: $GIT_BRANCH"
+ARG CACHE_BUST_SMLP
+ARG GIT_BRANCH=master
+COPY run_git_clone .
+RUN ./run_git_clone $GIT_BRANCH
+# Build SMLP
+
+#Layer 9: UTF-8 fonts
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+#Layer 10: Virtual display and VNC
+COPY open_virtual_display .
+COPY start_vnc .
+
+## Default command
+CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile.python311-dev_26.04
+++ b/scripts/docker/Dockerfile.python311-dev_26.04
@@ -71,11 +71,7 @@ RUN ./validate.sh
 COPY run_mathsat_build .
 RUN ./run_mathsat_build && rm -rf /tmp/mathsat*
 
-#Layer 7: tkdiff patch for https://bugs.launchpad.net/bugs/2139062
-COPY run_tkdiff_patch .
-RUN ./run_tkdiff_patch
-
-#Layer 8: git clone
+#Layer 7: git clone
 RUN echo "Building image for branch: $GIT_BRANCH"
 ARG CACHE_BUST_SMLP
 ARG GIT_BRANCH=master
@@ -83,13 +79,13 @@ COPY run_git_clone .
 RUN ./run_git_clone $GIT_BRANCH
 # Build SMLP
 
-#Layer 9: UTF-8 fonts
+#Layer 8: UTF-8 fonts
 RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-#Layer 10: Virtual display and VNC
+#Layer 9: Virtual display and VNC
 COPY open_virtual_display .
 COPY start_vnc .
 

--- a/scripts/docker/Dockerfile.python311-dev_26.04
+++ b/scripts/docker/Dockerfile.python311-dev_26.04
@@ -64,6 +64,7 @@ RUN PYTHON="python3.11" \
  && printf '#!/bin/bash\nset -e\n' > validate.sh \
  && printf '%s -c "import smlp; from importlib.metadata import version; print('"'"'smlp version:'"'"', version('"'"'smlptech'"'"'))"\n' "$PYTHON" >> validate.sh \
  && printf '%s -c "import tkinter; print('"'"'tkinter Tcl/Tk:'"'"', tkinter.TclVersion)"\n'                                             "$PYTHON" >> validate.sh \
+ && chmod +x validate.sh
 RUN ./validate.sh
 
 # Layer 6: Mathsat 

--- a/scripts/docker/Dockerfile.smlp-test-build-ubuntu_26.04-python311
+++ b/scripts/docker/Dockerfile.smlp-test-build-ubuntu_26.04-python311
@@ -1,0 +1,110 @@
+FROM ubuntu:26.04
+
+# ── Install mode ───────────────────────────────────────────────────────────────
+# INSTALL_MODE=venv   (default) : install into a per-user virtual environment
+# INSTALL_MODE=system           : install system-wide via: sudo pip3.11 install
+ARG INSTALL_MODE=venv
+ARG RELEASE_TYPE
+
+# 1. ── system deps + deadsnakes PPA for Python 3.11 ──────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo \
+        software-properties-common \
+        git \
+        jq \
+        libgomp1 \
+        locales \
+        tcsh \
+        tzdata \
+        vim \
+        wget \
+        x11-xserver-utils \
+        xvfb \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-venv \
+        python3.11-tk \
+    &&  python3.11 -m ensurepip \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. ── non-root user with passwordless sudo ───────────────────────────────────────
+ARG USERNAME=testuser
+ARG USER_UID=1001
+ARG USER_GID=1001
+
+RUN groupadd --gid "${USER_GID}" "${USERNAME}" \
+ && useradd --uid "${USER_UID}" --gid "${USER_GID}" \
+            --create-home --shell /bin/bash "${USERNAME}" \
+ && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" \
+        > /etc/sudoers.d/${USERNAME} \
+ && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# 3. ── switch to the test user ────────────────────────────────────────────────────
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+# 4. ── Install smlptech  ──────────────────────────────────────────────────────────
+COPY run_pip_install  .
+COPY smlp_versions.py .
+RUN if [ "$INSTALL_MODE" = "venv" ]; then \
+        python3.11 -m venv .venv \
+     && export PATH=/home/$(whoami)/.venv/bin:${PATH} \
+     && echo "Installing SMLP in user mode" \
+     && . .venv/bin/activate && ./run_pip_install $RELEASE_TYPE; \
+    elif [ "$INSTALL_MODE" = "system" ]; then \
+        echo "Installing SMLP in system mode" \
+     && sudo ./run_pip_install $RELEASE_TYPE; \
+    else \
+        echo "ERROR: unknown INSTALL_MODE=$INSTALL_MODE (expected: venv | system)" >&2; exit 1; \
+    fi
+
+# 5. ── Write validate.sh — python path depends on install mode ───────────────────
+RUN if [ "${INSTALL_MODE}" = "venv" ]; then \
+        PYTHON=".venv/bin/python3.11"; \
+    else \
+        PYTHON="python3.11"; \
+    fi \
+ && printf '#!/bin/bash\nset -e\n' > validate.sh \
+ && printf '%s -c "import smlp; from importlib.metadata import version; print('"'"'smlp version:'"'"', version('"'"'smlptech'"'"'))"\n' "$PYTHON" >> validate.sh \
+ && printf '%s -c "import tkinter; print('"'"'tkinter Tcl/Tk:'"'"', tkinter.TclVersion)"\n' "$PYTHON" >> validate.sh \
+ && printf 'echo "sudo check:"\n' >> validate.sh \
+ && printf 'sudo --non-interactive whoami\n' >> validate.sh \
+ && chmod +x validate.sh
+
+# 6. ─── Validate installation ──────────────────────────────────────────────────────────────
+RUN ./validate.sh
+
+# 7. ─── Validate Z3 version   ──────────────────────────────────────────────────────────────
+ENV PATH=/home/${USERNAME}/.venv/bin:${PATH} 
+RUN printf '#!/usr/bin/env python3.11\n' > z3_version.py \
+    && printf 'from ctypes import cdll, c_char_p\n'  >> z3_version.py \
+    && printf 'from smlp import core\n' >> z3_version.py \
+    && printf 'libsmlp=cdll.LoadLibrary(core.libsmlp.__file__)\n' >> z3_version.py \
+    && printf 'z3_version=libsmlp.Z3_get_full_version\n' >> z3_version.py \
+    && printf 'z3_version.restype=c_char_p\n' >> z3_version.py \
+    && printf 'print(z3_version().decode())\n' >> z3_version.py \
+    && chmod +x z3_version.py && ./z3_version.py
+
+# 8. ─── Optional: install helper script for virtual display in order to enable non-GUI mode 
+COPY open_virtual_display .
+
+# 9. ─── Optional: install UTF-8 fonts ──────────────────────────────────────────────────────
+RUN sudo locale-gen en_US.UTF-8 && \
+    sudo update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LANGUAGE=en_US:en
+
+# 10. ─── Optional: install MathSAT ───────────────────────────────────────────────────────────────────────────────────
+ARG GIT_BRANCH=master
+RUN wget https://raw.githubusercontent.com/SMLP-Systems/smlp/refs/heads/$GIT_BRANCH/scripts/docker/run_mathsat_build
+RUN chmod +x run_mathsat_build
+RUN ./run_mathsat_build && rm -rf /tmp/mathsat* && external/mathsat-5.6.8-linux-x86_64-reentrant/bin/mathsat -version
+
+# 11. ── For SMLP developers: clone smlp (ARG busts the cache to always get latest) ───────────────────────────────────
+ARG CACHE_BUST_SMLP
+ARG RELEASE_TYPE
+RUN echo "Building image for branch: $GIT_BRANCH"
+COPY run_git_clone .
+RUN ./run_git_clone $GIT_BRANCH
+
+# ── Default command ──────────────────────────────────────────────────────────────────────────────────────────
+CMD ["bash"]

--- a/scripts/venv/Dockerfile.readme_system_26.04
+++ b/scripts/venv/Dockerfile.readme_system_26.04
@@ -1,0 +1,26 @@
+FROM ubuntu:26.04
+RUN apt-get update
+RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+RUN apt-get install -y sudo
+ARG USERNAME=testuser
+ARG USER_UID=1001
+ARG USER_GID=1001
+RUN groupadd --gid "${USER_GID}" "${USERNAME}" \
+ && useradd --uid "${USER_UID}" --gid "${USER_GID}" \
+            --create-home --shell /bin/bash "${USERNAME}" \
+ && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" \
+        > /etc/sudoers.d/${USERNAME} \
+ && chmod 0440 /etc/sudoers.d/${USERNAME}
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+COPY README_system.sourceme .
+RUN bash -c 'source README_system.sourceme'
+RUN printf '#!/usr/bin/env python3.11\n' > z3_version.py \
+    && printf 'from ctypes import cdll, c_char_p\n'  >> z3_version.py \
+    && printf 'from smlp import core\n' >> z3_version.py \
+    && printf 'libsmlp=cdll.LoadLibrary(core.libsmlp.__file__)\n' >> z3_version.py \
+    && printf 'z3_version=libsmlp.Z3_get_full_version\n' >> z3_version.py \
+    && printf 'z3_version.restype=c_char_p\n' >> z3_version.py \
+    && printf 'print(z3_version().decode())\n' >> z3_version.py \
+    && chmod +x z3_version.py
+RUN ./z3_version.py

--- a/scripts/venv/Dockerfile.readme_venv_26.04
+++ b/scripts/venv/Dockerfile.readme_venv_26.04
@@ -1,0 +1,27 @@
+FROM ubuntu:26.04
+RUN apt-get update
+RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
+RUN apt-get install -y sudo
+ARG USERNAME=testuser
+ARG USER_UID=1001
+ARG USER_GID=1001
+RUN groupadd --gid "${USER_GID}" "${USERNAME}" \
+ && useradd --uid "${USER_UID}" --gid "${USER_GID}" \
+            --create-home --shell /bin/bash "${USERNAME}" \
+ && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" \
+        > /etc/sudoers.d/${USERNAME} \
+ && chmod 0440 /etc/sudoers.d/${USERNAME}
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+COPY README_venv.sourceme .
+RUN bash -c 'source README_venv.sourceme'
+ENV PATH=/home/${USERNAME}/.venv/bin:${PATH}
+RUN printf '#!/usr/bin/env python3.11\n' > z3_version.py \
+    && printf 'from ctypes import cdll, c_char_p\n'  >> z3_version.py \
+    && printf 'from smlp import core\n' >> z3_version.py \
+    && printf 'libsmlp=cdll.LoadLibrary(core.libsmlp.__file__)\n' >> z3_version.py \
+    && printf 'z3_version=libsmlp.Z3_get_full_version\n' >> z3_version.py \
+    && printf 'z3_version.restype=c_char_p\n' >> z3_version.py \
+    && printf 'print(z3_version().decode())\n' >> z3_version.py \
+    && chmod +x z3_version.py
+RUN ./z3_version.py


### PR DESCRIPTION
#### Build commands

```bash
git clone -b smlp_ubuntu2604 ssh://git@github.com/SMLP-Systems/smlp smlp_ubuntu2604
cd smlp_ubuntu2604/scripts/docker
make IMAGE=smlp-test-build-ubuntu_26.04-python311
```

Regression passed for the `smlptech==1.2.0`

Reference image: 

```bash
docker pull mdmitry1/smlp-test-build-ubuntu_26.04-python311:latest
```